### PR TITLE
Add ClaudePocket setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "ClaudePocket Setup",
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && npm install -g claude-code-mobile-terminal-server",
+  "postStartCommand": "gh codespace ports visibility 8080:public -c $CODESPACE_NAME && cc-mobile-server start",
+  "forwardPorts": [
+    8080
+  ],
+  "portsAttributes": {
+    "8080": {
+      "label": "Claude Code Terminal Server",
+      "onAutoForward": "notify"
+    }
+  }
+}


### PR DESCRIPTION
## ClaudePocket Setup

This PR adds a devcontainer configuration to enable ClaudePocket terminal server.

### What this adds:
- ✅ Auto-installs `claude-code-mobile-terminal-server`
- ✅ Starts terminal server on port 8080  
- ✅ Forwards port for mobile access

### Usage:
1. Create a codespace from this PR
2. Terminal server will auto-start
3. Connect from ClaudePocket PWA

*This PR was created automatically by ClaudePocket*